### PR TITLE
(fix) is_occupied is true in the run

### DIFF
--- a/src/quotient_filter.rs
+++ b/src/quotient_filter.rs
@@ -99,7 +99,9 @@ impl QuotientFilter {
         let mut curr = empty_pos;
         while curr != s {
             let prev = (curr + self.size - 1) % self.size;
-            self.filter[curr] = self.filter[prev].clone();
+            let prev_slot = self.filter[prev].clone();
+            self.filter[curr].remainder = prev_slot.remainder;
+            self.filter[curr].is_continued = prev_slot.is_continued;
             self.filter[curr].is_shifted = true;
             curr = prev;
         }
@@ -251,6 +253,24 @@ mod test {
         assert!(!qf.filter[idx].is_continued);
         assert!(qf.filter[idx + 1].is_continued);
         assert!(qf.filter[idx + 2].is_continued);
+    }
+
+    #[test]
+    fn test_insert_preserves_occupied_bitmap() {
+        let mut qf = QuotientFilter::new(4, 4);
+
+        // Insert larger remainder first so the later insert shifts the run head.
+        qf.insert(0b0001_0010);
+        qf.insert(0b0001_0001);
+
+        assert!(
+            qf.filter[1].is_occupied,
+            "home bucket for quotient=1 must remain occupied"
+        );
+        assert!(
+            !qf.filter[2].is_occupied,
+            "inserting only quotient=1 elements must not mark quotient=2 as occupied"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 概要
Quotient Filterの `insert` メソッドにおいて、runのシフト処理中に `is_occupied` ビットが誤ってコピーされてしまう問題を修正しました。

## 問題
スロットをシフトする際に、単純に `self.filter[curr] = self.filter[prev].clone()` を使用していたため、`is_occupied` ビットも含めてすべてのフィールドがコピーされていました。これにより、本来占有されていないquotientのホームバケットが、誤って占有済みとマークされる問題が発生していました。

## 修正内容
- シフト処理において、`remainder` と `is_continued` フラグのみを明示的にコピーするように変更
- `is_occupied` ビットは元の値を保持することで、各バケットの占有状態を正しく維持
- この動作を検証するための新しいテストケース `test_insert_preserves_occupied_bitmap` を追加

## 変更ファイル
- `src/quotient_filter.rs`

## テスト
新しいテストケースでは、より大きいremainderを先に挿入した後、より小さいremainderを挿入することで、runのヘッドがシフトされるケースを検証しています。これにより、quotient=1のホームバケットが占有されたまま維持され、quotient=2のバケットが誤って占有済みとマークされないことを確認しています。